### PR TITLE
[feat] Board 및 Comment 엔티티를 설계한다

### DIFF
--- a/src/main/generated/TeamDustKGU/dustbackend/user/domain/QUser.java
+++ b/src/main/generated/TeamDustKGU/dustbackend/user/domain/QUser.java
@@ -26,9 +26,9 @@ public class QUser extends EntityPathBase<User> {
 
     public final NumberPath<Integer> auth = createNumber("auth", Integer.class);
 
-    public final ListPath<TeamDustKGU.dustbackend.board.Board, TeamDustKGU.dustbackend.board.QBoard> boardList = this.<TeamDustKGU.dustbackend.board.Board, TeamDustKGU.dustbackend.board.QBoard>createList("boardList", TeamDustKGU.dustbackend.board.Board.class, TeamDustKGU.dustbackend.board.QBoard.class, PathInits.DIRECT2);
+    public final ListPath<TeamDustKGU.dustbackend.board.domain.Board, TeamDustKGU.dustbackend.board.domain.QBoard> boardList = this.<TeamDustKGU.dustbackend.board.domain.Board, TeamDustKGU.dustbackend.board.domain.QBoard>createList("boardList", TeamDustKGU.dustbackend.board.domain.Board.class, TeamDustKGU.dustbackend.board.domain.QBoard.class, PathInits.DIRECT2);
 
-    public final ListPath<TeamDustKGU.dustbackend.comment.Comment, TeamDustKGU.dustbackend.comment.QComment> commentList = this.<TeamDustKGU.dustbackend.comment.Comment, TeamDustKGU.dustbackend.comment.QComment>createList("commentList", TeamDustKGU.dustbackend.comment.Comment.class, TeamDustKGU.dustbackend.comment.QComment.class, PathInits.DIRECT2);
+    public final ListPath<TeamDustKGU.dustbackend.comment.domain.Comment, TeamDustKGU.dustbackend.comment.domain.QComment> commentList = this.<TeamDustKGU.dustbackend.comment.domain.Comment, TeamDustKGU.dustbackend.comment.domain.QComment>createList("commentList", TeamDustKGU.dustbackend.comment.domain.Comment.class, TeamDustKGU.dustbackend.comment.domain.QComment.class, PathInits.DIRECT2);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdDate = _super.createdDate;

--- a/src/main/java/TeamDustKGU/dustbackend/board/domain/Board.java
+++ b/src/main/java/TeamDustKGU/dustbackend/board/domain/Board.java
@@ -1,6 +1,6 @@
-package TeamDustKGU.dustbackend.board;
+package TeamDustKGU.dustbackend.board.domain;
 
-import TeamDustKGU.dustbackend.comment.Comment;
+import TeamDustKGU.dustbackend.comment.domain.Comment;
 import TeamDustKGU.dustbackend.global.BaseTimeEntity;
 import TeamDustKGU.dustbackend.user.domain.User;
 import lombok.AccessLevel;

--- a/src/main/java/TeamDustKGU/dustbackend/comment/domain/Comment.java
+++ b/src/main/java/TeamDustKGU/dustbackend/comment/domain/Comment.java
@@ -1,6 +1,6 @@
-package TeamDustKGU.dustbackend.comment;
+package TeamDustKGU.dustbackend.comment.domain;
 
-import TeamDustKGU.dustbackend.board.Board;
+import TeamDustKGU.dustbackend.board.domain.Board;
 import TeamDustKGU.dustbackend.global.BaseTimeEntity;
 import TeamDustKGU.dustbackend.user.domain.User;
 import lombok.AccessLevel;

--- a/src/main/java/TeamDustKGU/dustbackend/user/domain/User.java
+++ b/src/main/java/TeamDustKGU/dustbackend/user/domain/User.java
@@ -1,7 +1,7 @@
 package TeamDustKGU.dustbackend.user.domain;
 
-import TeamDustKGU.dustbackend.board.Board;
-import TeamDustKGU.dustbackend.comment.Comment;
+import TeamDustKGU.dustbackend.board.domain.Board;
+import TeamDustKGU.dustbackend.comment.domain.Comment;
 import TeamDustKGU.dustbackend.global.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/test/java/TeamDustKGU/dustbackend/board/domain/BoardTest.java
+++ b/src/test/java/TeamDustKGU/dustbackend/board/domain/BoardTest.java
@@ -1,7 +1,7 @@
 package TeamDustKGU.dustbackend.board.domain;
 
-import TeamDustKGU.dustbackend.board.Board;
-import TeamDustKGU.dustbackend.comment.Comment;
+import TeamDustKGU.dustbackend.board.domain.Board;
+import TeamDustKGU.dustbackend.comment.domain.Comment;
 import TeamDustKGU.dustbackend.user.domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/TeamDustKGU/dustbackend/comment/domain/CommentTest.java
+++ b/src/test/java/TeamDustKGU/dustbackend/comment/domain/CommentTest.java
@@ -1,7 +1,7 @@
 package TeamDustKGU.dustbackend.comment.domain;
 
-import TeamDustKGU.dustbackend.board.Board;
-import TeamDustKGU.dustbackend.comment.Comment;
+import TeamDustKGU.dustbackend.board.domain.Board;
+import TeamDustKGU.dustbackend.comment.domain.Comment;
 import TeamDustKGU.dustbackend.user.domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/TeamDustKGU/dustbackend/fixture/BoardFixture.java
+++ b/src/test/java/TeamDustKGU/dustbackend/fixture/BoardFixture.java
@@ -1,6 +1,6 @@
 package TeamDustKGU.dustbackend.fixture;
 
-import TeamDustKGU.dustbackend.board.Board;
+import TeamDustKGU.dustbackend.board.domain.Board;
 import TeamDustKGU.dustbackend.user.domain.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/TeamDustKGU/dustbackend/fixture/CommentFixture.java
+++ b/src/test/java/TeamDustKGU/dustbackend/fixture/CommentFixture.java
@@ -1,7 +1,7 @@
 package TeamDustKGU.dustbackend.fixture;
 
-import TeamDustKGU.dustbackend.board.Board;
-import TeamDustKGU.dustbackend.comment.Comment;
+import TeamDustKGU.dustbackend.board.domain.Board;
+import TeamDustKGU.dustbackend.comment.domain.Comment;
 import TeamDustKGU.dustbackend.user.domain.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
### SUMMARY
- Board 및 Comment 엔티티를 설계한다

### DESCRIBE YOUR CHANGES
- Board Entity 설계
- Comment Entity 설계
- BoardTest 추가
- CommentTest 추가
- CASCADE 옵션 적용
  - User 삭제 시 작성한 게시글, 댓글 모두 삭제
  - Board 삭제 시 달려있는 댓글 모두 삭제
  - Comment 삭제 시 자식 댓글 모두 삭제

### CHECK LIST
- [X] 게시글 entity 설계
- [X] 댓글 entity 설계 (대댓글 포함)
- [X] 테스트 코드 작성

### ISSEU NUMBERS AND LINK
Closes #13 
